### PR TITLE
Update README.md : add missing `function` keyword in React example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ importing them as ESModule as you usually would.
 ```jsx
 import React, {useState} from 'react';
 
-export MyComponent(){
+export function MyComponent() {
   const [count, setCount] = useState(0);
 
   return <div>Count {count} <button onClick={() => setCount(count + 1)}>Add to count</button></div>;


### PR DESCRIPTION
add missing `function` keyword in React example